### PR TITLE
Made Arduino Print Timestamp

### DIFF
--- a/src/Arduino/main/main.ino
+++ b/src/Arduino/main/main.ino
@@ -33,6 +33,11 @@ void loop() {
   sensors_event_t a, g, temp;
   mpu.getEvent(&a, &g, &temp);
 
+  /* Print out timestamp */
+  Serial.print("Time:");
+  Serial.print(a.timestamp);
+  Serial.print(",");
+
   /* Print out the values */
   Serial.print("AccelX:");
   Serial.print(a.acceleration.x);


### PR DESCRIPTION
I found that the struct used here: 
 https://github.com/kennedyengineering/EE525_Final_Project/blob/a8ea29e6a6ddec4aeefceb3ba539bf6ca5566b69/src/Arduino/main/main.ino#L33

Contains the timestamp (in milliseconds) of when the reading was taken. I verified that all timestamps (accel, gyro, and temp) were identical, so I decided to print the accel timestamp.